### PR TITLE
Added initial private field for creating and posting new topic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,5 @@ theme/*.sublime-workspace
 theme/.idea
 theme/.vscode
 theme/node_modules/
+
+.prettierrc.json

--- a/public/openapi/components/schemas/TopicObject.yaml
+++ b/public/openapi/components/schemas/TopicObject.yaml
@@ -158,6 +158,8 @@ TopicObject:
           type: boolean
         unread:
           type: boolean
+        private:
+          type: boolean
         bookmark:
           nullable: true
           type: number

--- a/src/topics/create.js
+++ b/src/topics/create.js
@@ -1,4 +1,3 @@
-
 'use strict';
 
 const _ = require('lodash');
@@ -21,7 +20,6 @@ module.exports = function (Topics) {
         const timestamp = data.timestamp || Date.now();
 
         const tid = await db.incrObjectField('global', 'nextTid');
-
         let topicData = {
             tid: tid,
             uid: data.uid,
@@ -33,13 +31,17 @@ module.exports = function (Topics) {
             lastposttime: 0,
             postcount: 0,
             viewcount: 0,
+            private: data.private == null ? false : data.private,
         };
 
         if (Array.isArray(data.tags) && data.tags.length) {
             topicData.tags = data.tags.join(',');
         }
 
-        const result = await plugins.hooks.fire('filter:topic.create', { topic: topicData, data: data });
+        const result = await plugins.hooks.fire('filter:topic.create', {
+            topic: topicData,
+            data: data,
+        });
         topicData = result.topic;
         await db.setObject(`topic:${topicData.tid}`, topicData);
 
@@ -56,12 +58,18 @@ module.exports = function (Topics) {
 
         await Promise.all([
             db.sortedSetsAdd(timestampedSortedSetKeys, timestamp, topicData.tid),
-            db.sortedSetsAdd([
-                'topics:views', 'topics:posts', 'topics:votes',
-                `cid:${topicData.cid}:tids:votes`,
-                `cid:${topicData.cid}:tids:posts`,
-                `cid:${topicData.cid}:tids:views`,
-            ], 0, topicData.tid),
+            db.sortedSetsAdd(
+                [
+                    'topics:views',
+                    'topics:posts',
+                    'topics:votes',
+                    `cid:${topicData.cid}:tids:votes`,
+                    `cid:${topicData.cid}:tids:posts`,
+                    `cid:${topicData.cid}:tids:views`,
+                ],
+                0,
+                topicData.tid
+            ),
             user.addTopicIdToUser(topicData.uid, topicData.tid, timestamp),
             db.incrObjectField(`category:${topicData.cid}`, 'topic_count'),
             db.incrObjectField('global', 'topicCount'),
@@ -71,8 +79,10 @@ module.exports = function (Topics) {
         if (scheduled) {
             await Topics.scheduled.pin(tid, topicData);
         }
-
-        plugins.hooks.fire('action:topic.save', { topic: _.clone(topicData), data: data });
+        plugins.hooks.fire('action:topic.save', {
+            topic: _.clone(topicData),
+            data: data,
+        });
         return topicData.tid;
     };
 
@@ -143,7 +153,11 @@ module.exports = function (Topics) {
         }
 
         analytics.increment(['topics', `topics:byCid:${topicData.cid}`]);
-        plugins.hooks.fire('action:topic.post', { topic: topicData, post: postData, data: data });
+        plugins.hooks.fire('action:topic.post', {
+            topic: topicData,
+            post: postData,
+            data: data,
+        });
 
         if (parseInt(uid, 10) && !topicData.scheduled) {
             user.notifications.sendTopicNotificationToFollowers(uid, topicData, postData);
@@ -205,7 +219,10 @@ module.exports = function (Topics) {
         }
 
         analytics.increment(['posts', `posts:byCid:${data.cid}`]);
-        plugins.hooks.fire('action:topic.reply', { post: _.clone(postData), data: data });
+        plugins.hooks.fire('action:topic.reply', {
+            post: _.clone(postData),
+            data: data,
+        });
 
         return postData;
     };
@@ -215,12 +232,19 @@ module.exports = function (Topics) {
         const { uid } = postData;
         await Topics.markAsUnreadForAll(tid);
         await Topics.markAsRead([tid], uid);
-        const [
-            userInfo,
-            topicInfo,
-        ] = await Promise.all([
+        const [userInfo, topicInfo] = await Promise.all([
             posts.getUserInfoForPosts([postData.uid], uid),
-            Topics.getTopicFields(tid, ['tid', 'uid', 'title', 'slug', 'cid', 'postcount', 'mainPid', 'scheduled']),
+            Topics.getTopicFields(tid, [
+                'tid',
+                'uid',
+                'title',
+                'slug',
+                'cid',
+                'postcount',
+                'mainPid',
+                'scheduled',
+                'private',
+            ]),
             Topics.addParentPosts([postData]),
             Topics.syncBacklinks(postData),
             posts.parsePost(postData),
@@ -246,11 +270,23 @@ module.exports = function (Topics) {
     }
 
     Topics.checkTitle = function (title) {
-        check(title, meta.config.minimumTitleLength, meta.config.maximumTitleLength, 'title-too-short', 'title-too-long');
+        check(
+            title,
+            meta.config.minimumTitleLength,
+            meta.config.maximumTitleLength,
+            'title-too-short',
+            'title-too-long'
+        );
     };
 
     Topics.checkContent = function (content) {
-        check(content, meta.config.minimumPostLength, meta.config.maximumPostLength, 'content-too-short', 'content-too-long');
+        check(
+            content,
+            meta.config.minimumPostLength,
+            meta.config.maximumPostLength,
+            'content-too-short',
+            'content-too-long'
+        );
     };
 
     function check(item, min, max, minError, maxError) {

--- a/src/topics/data.js
+++ b/src/topics/data.js
@@ -9,9 +9,21 @@ const translator = require('../translator');
 const plugins = require('../plugins');
 
 const intFields = [
-    'tid', 'cid', 'uid', 'mainPid', 'postcount',
-    'viewcount', 'postercount', 'deleted', 'locked', 'pinned',
-    'pinExpiry', 'timestamp', 'upvotes', 'downvotes', 'lastposttime',
+    'tid',
+    'cid',
+    'uid',
+    'mainPid',
+    'postcount',
+    'viewcount',
+    'postercount',
+    'deleted',
+    'locked',
+    'pinned',
+    'pinExpiry',
+    'timestamp',
+    'upvotes',
+    'downvotes',
+    'lastposttime',
     'deleterUid',
 ];
 
@@ -26,7 +38,8 @@ module.exports = function (Topics) {
             fields.push('timestamp');
         }
 
-        const keys = tids.map(tid => `topic:${tid}`);
+        // eslint-disable-next-line arrow-parens
+        const keys = tids.map((tid) => `topic:${tid}`);
         const topics = await db.getObjects(keys, fields);
         const result = await plugins.hooks.fire('filter:topic.getFields', {
             tids: tids,
@@ -34,7 +47,8 @@ module.exports = function (Topics) {
             fields: fields,
             keys: keys,
         });
-        result.topics.forEach(topic => modifyTopic(topic, fields));
+        // eslint-disable-next-line arrow-parens
+        result.topics.forEach((topic) => modifyTopic(topic, fields));
         return result.topics;
     };
 
@@ -123,20 +137,27 @@ function modifyTopic(topic, fields) {
         topic.votes = topic.upvotes - topic.downvotes;
     }
 
+    if (topic.hasOwnProperty('private')) {
+        topic.private = topic.private === 'true';
+    }
+
     if (fields.includes('teaserPid') || !fields.length) {
         topic.teaserPid = topic.teaserPid || null;
     }
 
     if (fields.includes('tags') || !fields.length) {
         const tags = String(topic.tags || '');
-        topic.tags = tags.split(',').filter(Boolean).map((tag) => {
-            const escaped = validator.escape(String(tag));
-            return {
-                value: tag,
-                valueEscaped: escaped,
-                valueEncoded: encodeURIComponent(escaped),
-                class: escaped.replace(/\s/g, '-'),
-            };
-        });
+        topic.tags = tags
+            .split(',')
+            .filter(Boolean)
+            .map((tag) => {
+                const escaped = validator.escape(String(tag));
+                return {
+                    value: tag,
+                    valueEscaped: escaped,
+                    valueEncoded: encodeURIComponent(escaped),
+                    class: escaped.replace(/\s/g, '-'),
+                };
+            });
     }
 }


### PR DESCRIPTION
Resolves #1 

## Description
* Adds a `private` field in the topicData object
* Sets `private` to false by default if not included in the request body, sets it to the private field provided by the request body otherwise
* Sets `private` to a boolean value
* Re-formatted long lines

## Motivation and Context
Sets up the backend for user story 1 ("as a student, I want to post questions to instructors only instead of the entire class, so that I can include private information or ask questions about my homework solutions") by adding the ability to save a topic as private, so that private status gets saved to the backend when a post request is made. 

## How Has This Been Tested?
* Created a new topic
* Checked that `api/topic/:tid/:title` has `private` field set to false

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [ ] I have written unit tests for my changes
-   [ ] I have updated the documentation accordingly, included in this PR

## Next Steps:
* Translate `src/topics/create.js` and `src/topics/data.js` TypeScript files
* Add private field to post request body on new post creation, based on the selected frontend value @apoznanski 