### PR TITLE
Convert `src/controllers/write/topics.js` from JS to TS

### DIFF
--- a/src/controllers/write/topics.js
+++ b/src/controllers/write/topics.js
@@ -1,160 +1,148 @@
 'use strict';
-
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
 const validator = require('validator');
 const _ = require('lodash');
-
 const db = require('../../database');
 const api = require('../../api');
 const topics = require('../../topics');
 const privileges = require('../../privileges');
 const plugins = require('../../plugins');
-
 const helpers = require('../helpers');
 const middleware = require('../../middleware');
 const uploadsController = require('../uploads');
-
 const Topics = module.exports;
-
-Topics.get = async (req, res) => {
-    helpers.formatApiResponse(200, res, await api.topics.get(req, req.params));
-};
-
-Topics.create = async (req, res) => {
-    const id = await lockPosting(req, '[[error:already-posting]]');
+Topics.get = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
+    helpers.formatApiResponse(200, res, yield api.topics.get(req, req.params));
+});
+Topics.create = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
+    const id = yield lockPosting(req, '[[error:already-posting]]');
     try {
-        const payload = await api.topics.create(req, req.body);
+        const payload = yield api.topics.create(req, req.body);
         if (payload.queued) {
             helpers.formatApiResponse(202, res, payload);
-        } else {
+        }
+        else {
             helpers.formatApiResponse(200, res, payload);
         }
-    } finally {
-        await db.deleteObjectField('locks', id);
     }
-};
-
-Topics.reply = async (req, res) => {
-    const id = await lockPosting(req, '[[error:already-posting]]');
+    finally {
+        yield db.deleteObjectField('locks', id);
+    }
+});
+Topics.reply = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
+    const id = yield lockPosting(req, '[[error:already-posting]]');
     try {
-        const payload = await api.topics.reply(req, { ...req.body, tid: req.params.tid });
+        const payload = yield api.topics.reply(req, Object.assign(Object.assign({}, req.body), { tid: req.params.tid }));
         helpers.formatApiResponse(200, res, payload);
-    } finally {
-        await db.deleteObjectField('locks', id);
     }
-};
-
-async function lockPosting(req, error) {
-    const id = req.uid > 0 ? req.uid : req.sessionID;
-    const value = `posting${id}`;
-    const count = await db.incrObjectField('locks', value);
-    if (count > 1) {
-        throw new Error(error);
+    finally {
+        yield db.deleteObjectField('locks', id);
     }
-    return value;
+});
+function lockPosting(req, error) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const id = req.uid > 0 ? req.uid : req.sessionID;
+        const value = `posting${id}`;
+        const count = yield db.incrObjectField('locks', value);
+        if (count > 1) {
+            throw new Error(error);
+        }
+        return value;
+    });
 }
-
-Topics.delete = async (req, res) => {
-    await api.topics.delete(req, { tids: [req.params.tid] });
+Topics.delete = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
+    yield api.topics.delete(req, { tids: [req.params.tid] });
     helpers.formatApiResponse(200, res);
-};
-
+});
 // added resolved field
-Topics.resolve = async (req, res) => {
-    await resolve(req.params.tid, req.uid);
+Topics.resolve = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
+    yield resolve(req.params.tid, req.uid);
     helpers.formatApiResponse(200, res);
-};
-
-async function resolve(tid, uid) {
-    const topicData = await topics.getTopicFields(tid, ['tid', 'uid', 'cid']);
-    if (!topicData || !topicData.cid) {
-        throw new Error('[[error:no-topic]]');
-    }
-    const isOwnerOrAdminOrMod = await privileges.topics.isOwnerOrAdminOrMod(tid, uid);
-    if (!isOwnerOrAdminOrMod) {
-        throw new Error('[[error:no-privileges]]');
-    }
-    await topics.setTopicField(tid, 'resolve', true);
-
-    topicData.resolve = true;
-
-    plugins.hooks.fire('action:topic.resolve', { topic: _.clone(topicData), uid: uid });
-    return topicData;
+});
+function resolve(tid, uid) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const topicData = yield topics.getTopicFields(tid, ['tid', 'uid', 'cid']);
+        if (!topicData || !topicData.cid) {
+            throw new Error('[[error:no-topic]]');
+        }
+        const isOwnerOrAdminOrMod = yield privileges.topics.isOwnerOrAdminOrMod(tid, uid);
+        if (!isOwnerOrAdminOrMod) {
+            throw new Error('[[error:no-privileges]]');
+        }
+        yield topics.setTopicField(tid, 'resolve', true);
+        topicData.resolve = true;
+        plugins.hooks.fire('action:topic.resolve', { topic: _.clone(topicData), uid: uid });
+        return topicData;
+    });
 }
-
-Topics.restore = async (req, res) => {
-    await api.topics.restore(req, { tids: [req.params.tid] });
+Topics.restore = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
+    yield api.topics.restore(req, { tids: [req.params.tid] });
     helpers.formatApiResponse(200, res);
-};
-
-Topics.purge = async (req, res) => {
-    await api.topics.purge(req, { tids: [req.params.tid] });
+});
+Topics.purge = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
+    yield api.topics.purge(req, { tids: [req.params.tid] });
     helpers.formatApiResponse(200, res);
-};
-
-Topics.pin = async (req, res) => {
+});
+Topics.pin = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
     // Pin expiry was not available w/ sockets hence not included in api lib method
     if (req.body.expiry) {
-        await topics.tools.setPinExpiry(req.params.tid, req.body.expiry, req.uid);
+        yield topics.tools.setPinExpiry(req.params.tid, req.body.expiry, req.uid);
     }
-    await api.topics.pin(req, { tids: [req.params.tid] });
-
+    yield api.topics.pin(req, { tids: [req.params.tid] });
     helpers.formatApiResponse(200, res);
-};
-
-Topics.unpin = async (req, res) => {
-    await api.topics.unpin(req, { tids: [req.params.tid] });
+});
+Topics.unpin = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
+    yield api.topics.unpin(req, { tids: [req.params.tid] });
     helpers.formatApiResponse(200, res);
-};
-
-Topics.lock = async (req, res) => {
-    await api.topics.lock(req, { tids: [req.params.tid] });
+});
+Topics.lock = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
+    yield api.topics.lock(req, { tids: [req.params.tid] });
     helpers.formatApiResponse(200, res);
-};
-
-Topics.unlock = async (req, res) => {
-    await api.topics.unlock(req, { tids: [req.params.tid] });
+});
+Topics.unlock = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
+    yield api.topics.unlock(req, { tids: [req.params.tid] });
     helpers.formatApiResponse(200, res);
-};
-
-Topics.follow = async (req, res) => {
-    await api.topics.follow(req, req.params);
+});
+Topics.follow = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
+    yield api.topics.follow(req, req.params);
     helpers.formatApiResponse(200, res);
-};
-
-Topics.ignore = async (req, res) => {
-    await api.topics.ignore(req, req.params);
+});
+Topics.ignore = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
+    yield api.topics.ignore(req, req.params);
     helpers.formatApiResponse(200, res);
-};
-
-Topics.unfollow = async (req, res) => {
-    await api.topics.unfollow(req, req.params);
+});
+Topics.unfollow = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
+    yield api.topics.unfollow(req, req.params);
     helpers.formatApiResponse(200, res);
-};
-
-Topics.addTags = async (req, res) => {
-    if (!await privileges.topics.canEdit(req.params.tid, req.user.uid)) {
+});
+Topics.addTags = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
+    if (!(yield privileges.topics.canEdit(req.params.tid, req.user.uid))) {
         return helpers.formatApiResponse(403, res);
     }
-    const cid = await topics.getTopicField(req.params.tid, 'cid');
-    await topics.validateTags(req.body.tags, cid, req.user.uid, req.params.tid);
-    const tags = await topics.filterTags(req.body.tags);
-
-    await topics.addTags(tags, [req.params.tid]);
+    const cid = yield topics.getTopicField(req.params.tid, 'cid');
+    yield topics.validateTags(req.body.tags, cid, req.user.uid, req.params.tid);
+    const tags = yield topics.filterTags(req.body.tags);
+    yield topics.addTags(tags, [req.params.tid]);
     helpers.formatApiResponse(200, res);
-};
-
-Topics.deleteTags = async (req, res) => {
-    if (!await privileges.topics.canEdit(req.params.tid, req.user.uid)) {
+});
+Topics.deleteTags = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
+    if (!(yield privileges.topics.canEdit(req.params.tid, req.user.uid))) {
         return helpers.formatApiResponse(403, res);
     }
-
-    await topics.deleteTopicTags(req.params.tid);
+    yield topics.deleteTopicTags(req.params.tid);
     helpers.formatApiResponse(200, res);
-};
-
-Topics.getThumbs = async (req, res) => {
+});
+Topics.getThumbs = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
     if (isFinite(req.params.tid)) { // post_uuids can be passed in occasionally, in that case no checks are necessary
-        const [exists, canRead] = await Promise.all([
+        const [exists, canRead] = yield Promise.all([
             topics.exists(req.params.tid),
             privileges.topics.can('topics:read', req.params.tid, req.uid),
         ]);
@@ -162,106 +150,90 @@ Topics.getThumbs = async (req, res) => {
             return helpers.formatApiResponse(403, res);
         }
     }
-
-    helpers.formatApiResponse(200, res, await topics.thumbs.get(req.params.tid));
-};
-
-Topics.addThumb = async (req, res) => {
-    await checkThumbPrivileges({ tid: req.params.tid, uid: req.user.uid, res });
+    helpers.formatApiResponse(200, res, yield topics.thumbs.get(req.params.tid));
+});
+Topics.addThumb = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
+    yield checkThumbPrivileges({ tid: req.params.tid, uid: req.user.uid, res });
     if (res.headersSent) {
         return;
     }
-
-    const files = await uploadsController.uploadThumb(req, res); // response is handled here
-
+    const files = yield uploadsController.uploadThumb(req, res); // response is handled here
     // Add uploaded files to topic zset
     if (files && files.length) {
-        await Promise.all(files.map(async (fileObj) => {
-            await topics.thumbs.associate({
+        yield Promise.all(files.map((fileObj) => __awaiter(void 0, void 0, void 0, function* () {
+            yield topics.thumbs.associate({
                 id: req.params.tid,
                 path: fileObj.path || fileObj.url,
             });
-        }));
+        })));
     }
-};
-
-Topics.migrateThumbs = async (req, res) => {
-    await Promise.all([
+});
+Topics.migrateThumbs = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
+    yield Promise.all([
         checkThumbPrivileges({ tid: req.params.tid, uid: req.user.uid, res }),
         checkThumbPrivileges({ tid: req.body.tid, uid: req.user.uid, res }),
     ]);
     if (res.headersSent) {
         return;
     }
-
-    await topics.thumbs.migrate(req.params.tid, req.body.tid);
+    yield topics.thumbs.migrate(req.params.tid, req.body.tid);
     helpers.formatApiResponse(200, res);
-};
-
-Topics.deleteThumb = async (req, res) => {
+});
+Topics.deleteThumb = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
     if (!req.body.path.startsWith('http')) {
-        await middleware.assert.path(req, res, () => {});
+        yield middleware.assert.path(req, res, () => { });
         if (res.headersSent) {
             return;
         }
     }
-
-    await checkThumbPrivileges({ tid: req.params.tid, uid: req.user.uid, res });
+    yield checkThumbPrivileges({ tid: req.params.tid, uid: req.user.uid, res });
     if (res.headersSent) {
         return;
     }
-
-    await topics.thumbs.delete(req.params.tid, req.body.path);
-    helpers.formatApiResponse(200, res, await topics.thumbs.get(req.params.tid));
-};
-
-Topics.reorderThumbs = async (req, res) => {
-    await checkThumbPrivileges({ tid: req.params.tid, uid: req.user.uid, res });
+    yield topics.thumbs.delete(req.params.tid, req.body.path);
+    helpers.formatApiResponse(200, res, yield topics.thumbs.get(req.params.tid));
+});
+Topics.reorderThumbs = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
+    yield checkThumbPrivileges({ tid: req.params.tid, uid: req.user.uid, res });
     if (res.headersSent) {
         return;
     }
-
-    const exists = await topics.thumbs.exists(req.params.tid, req.body.path);
+    const exists = yield topics.thumbs.exists(req.params.tid, req.body.path);
     if (!exists) {
         return helpers.formatApiResponse(404, res);
     }
-
-    await topics.thumbs.associate({
+    yield topics.thumbs.associate({
         id: req.params.tid,
         path: req.body.path,
         score: req.body.order,
     });
     helpers.formatApiResponse(200, res);
-};
-
-async function checkThumbPrivileges({ tid, uid, res }) {
-    // req.params.tid could be either a tid (pushing a new thumb to an existing topic)
-    // or a post UUID (a new topic being composed)
-    const isUUID = validator.isUUID(tid);
-
-    // Sanity-check the tid if it's strictly not a uuid
-    if (!isUUID && (isNaN(parseInt(tid, 10)) || !await topics.exists(tid))) {
-        return helpers.formatApiResponse(404, res, new Error('[[error:no-topic]]'));
-    }
-
-    // While drafts are not protected, tids are
-    if (!isUUID && !await privileges.topics.canEdit(tid, uid)) {
-        return helpers.formatApiResponse(403, res, new Error('[[error:no-privileges]]'));
-    }
+});
+function checkThumbPrivileges({ tid, uid, res }) {
+    return __awaiter(this, void 0, void 0, function* () {
+        // req.params.tid could be either a tid (pushing a new thumb to an existing topic)
+        // or a post UUID (a new topic being composed)
+        const isUUID = validator.isUUID(tid);
+        // Sanity-check the tid if it's strictly not a uuid
+        if (!isUUID && (isNaN(parseInt(tid, 10)) || !(yield topics.exists(tid)))) {
+            return helpers.formatApiResponse(404, res, new Error('[[error:no-topic]]'));
+        }
+        // While drafts are not protected, tids are
+        if (!isUUID && !(yield privileges.topics.canEdit(tid, uid))) {
+            return helpers.formatApiResponse(403, res, new Error('[[error:no-privileges]]'));
+        }
+    });
 }
-
-Topics.getEvents = async (req, res) => {
-    if (!await privileges.topics.can('topics:read', req.params.tid, req.uid)) {
+Topics.getEvents = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
+    if (!(yield privileges.topics.can('topics:read', req.params.tid, req.uid))) {
         return helpers.formatApiResponse(403, res);
     }
-
-    helpers.formatApiResponse(200, res, await topics.events.get(req.params.tid, req.uid));
-};
-
-Topics.deleteEvent = async (req, res) => {
-    if (!await privileges.topics.isAdminOrMod(req.params.tid, req.uid)) {
+    helpers.formatApiResponse(200, res, yield topics.events.get(req.params.tid, req.uid));
+});
+Topics.deleteEvent = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
+    if (!(yield privileges.topics.isAdminOrMod(req.params.tid, req.uid))) {
         return helpers.formatApiResponse(403, res);
     }
-    await topics.events.purge(req.params.tid, [req.params.eventId]);
+    yield topics.events.purge(req.params.tid, [req.params.eventId]);
     helpers.formatApiResponse(200, res);
-};
+});

--- a/src/controllers/write/topics.js
+++ b/src/controllers/write/topics.js
@@ -1,239 +1,312 @@
-'use strict';
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
 };
-const validator = require('validator');
-const _ = require('lodash');
-const db = require('../../database');
-const api = require('../../api');
-const topics = require('../../topics');
-const privileges = require('../../privileges');
-const plugins = require('../../plugins');
-const helpers = require('../helpers');
-const middleware = require('../../middleware');
-const uploadsController = require('../uploads');
-const Topics = module.exports;
-Topics.get = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
-    helpers.formatApiResponse(200, res, yield api.topics.get(req, req.params));
-});
-Topics.create = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
-    const id = yield lockPosting(req, '[[error:already-posting]]');
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.deleteEvent = exports.getEvents = exports.reorderThumbs = exports.deleteThumb = exports.migrateThumbs = exports.addThumb = exports.getThumbs = exports.deleteTags = exports.addTags = exports.unfollow = exports.ignore = exports.follow = exports.unlock = exports.lock = exports.unpin = exports.pin = exports.purge = exports.restore = exports.resolve = exports.deleteTopic = exports.reply = exports.create = exports.get = void 0;
+const validator_1 = __importDefault(require("validator"));
+const lodash_1 = __importDefault(require("lodash"));
+const database_1 = __importDefault(require("../../database"));
+const api_1 = __importDefault(require("../../api"));
+const topics_1 = __importDefault(require("../../topics"));
+const privileges_1 = __importDefault(require("../../privileges"));
+const plugins_1 = __importDefault(require("../../plugins"));
+const helpers_1 = __importDefault(require("../helpers"));
+const middleware_1 = __importDefault(require("../../middleware"));
+const uploads_1 = __importDefault(require("../uploads"));
+const get = async (req, res) => {
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    await helpers_1.default.formatApiResponse(200, res, await api_1.default.topics.get(req, req.params));
+};
+exports.get = get;
+async function lockPosting(req, error) {
+    const id = req.uid > 0 ? req.uid : req.sessionID;
+    const value = `posting${id}`;
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    const count = await database_1.default.incrObjectField('locks', value);
+    if (count > 1) {
+        throw new Error(error);
+    }
+    return value;
+}
+const create = async (req, res) => {
+    const id = await lockPosting(req, '[[error:already-posting]]');
     try {
-        const payload = yield api.topics.create(req, req.body);
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        const payload = await api_1.default.topics.create(req, req.body);
         if (payload.queued) {
-            helpers.formatApiResponse(202, res, payload);
+            await helpers_1.default.formatApiResponse(202, res, payload);
         }
         else {
-            helpers.formatApiResponse(200, res, payload);
+            await helpers_1.default.formatApiResponse(200, res, payload);
         }
     }
     finally {
-        yield db.deleteObjectField('locks', id);
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        await database_1.default.deleteObjectField('locks', id);
     }
-});
-Topics.reply = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
-    const id = yield lockPosting(req, '[[error:already-posting]]');
+};
+exports.create = create;
+const reply = async (req, res) => {
+    const id = await lockPosting(req, '[[error:already-posting]]');
     try {
-        const payload = yield api.topics.reply(req, Object.assign(Object.assign({}, req.body), { tid: req.params.tid }));
-        helpers.formatApiResponse(200, res, payload);
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        const payload = await api_1.default.topics.reply(req, Object.assign(Object.assign({}, req.body), { tid: req.params.tid }));
+        await helpers_1.default.formatApiResponse(200, res, payload);
     }
     finally {
-        yield db.deleteObjectField('locks', id);
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        await database_1.default.deleteObjectField('locks', id);
     }
-});
-function lockPosting(req, error) {
-    return __awaiter(this, void 0, void 0, function* () {
-        const id = req.uid > 0 ? req.uid : req.sessionID;
-        const value = `posting${id}`;
-        const count = yield db.incrObjectField('locks', value);
-        if (count > 1) {
-            throw new Error(error);
-        }
-        return value;
-    });
+};
+exports.reply = reply;
+const deleteTopic = async (req, res) => {
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    await api_1.default.topics.delete(req, { tids: [req.params.tid] });
+    await helpers_1.default.formatApiResponse(200, res);
+};
+exports.deleteTopic = deleteTopic;
+async function resolveTopic(tid, uid) {
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    const topicData = await topics_1.default.getTopicFields(tid, ['tid', 'uid', 'cid']);
+    if (!topicData || !topicData.cid) {
+        throw new Error('[[error:no-topic]]');
+    }
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    const isOwnerOrAdminOrMod = await privileges_1.default.topics.isOwnerOrAdminOrMod(tid, uid);
+    if (!isOwnerOrAdminOrMod) {
+        throw new Error('[[error:no-privileges]]');
+    }
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    await topics_1.default.setTopicField(tid, 'resolve', true);
+    topicData.resolve = true;
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    await plugins_1.default.hooks.fire('action:topic.resolve', { topic: lodash_1.default.clone(topicData), uid: uid });
+    return topicData;
 }
-Topics.delete = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
-    yield api.topics.delete(req, { tids: [req.params.tid] });
-    helpers.formatApiResponse(200, res);
-});
 // added resolved field
-Topics.resolve = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
-    yield resolve(req.params.tid, req.uid);
-    helpers.formatApiResponse(200, res);
-});
-function resolve(tid, uid) {
-    return __awaiter(this, void 0, void 0, function* () {
-        const topicData = yield topics.getTopicFields(tid, ['tid', 'uid', 'cid']);
-        if (!topicData || !topicData.cid) {
-            throw new Error('[[error:no-topic]]');
-        }
-        const isOwnerOrAdminOrMod = yield privileges.topics.isOwnerOrAdminOrMod(tid, uid);
-        if (!isOwnerOrAdminOrMod) {
-            throw new Error('[[error:no-privileges]]');
-        }
-        yield topics.setTopicField(tid, 'resolve', true);
-        topicData.resolve = true;
-        plugins.hooks.fire('action:topic.resolve', { topic: _.clone(topicData), uid: uid });
-        return topicData;
-    });
-}
-Topics.restore = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
-    yield api.topics.restore(req, { tids: [req.params.tid] });
-    helpers.formatApiResponse(200, res);
-});
-Topics.purge = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
-    yield api.topics.purge(req, { tids: [req.params.tid] });
-    helpers.formatApiResponse(200, res);
-});
-Topics.pin = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
+const resolve = async (req, res) => {
+    await resolveTopic(req.params.tid, req.uid);
+    await helpers_1.default.formatApiResponse(200, res);
+};
+exports.resolve = resolve;
+const restore = async (req, res) => {
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    await api_1.default.topics.restore(req, { tids: [req.params.tid] });
+    await helpers_1.default.formatApiResponse(200, res);
+};
+exports.restore = restore;
+const purge = async (req, res) => {
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    await api_1.default.topics.purge(req, { tids: [req.params.tid] });
+    await helpers_1.default.formatApiResponse(200, res);
+};
+exports.purge = purge;
+const pin = async (req, res) => {
     // Pin expiry was not available w/ sockets hence not included in api lib method
     if (req.body.expiry) {
-        yield topics.tools.setPinExpiry(req.params.tid, req.body.expiry, req.uid);
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        await topics_1.default.tools.setPinExpiry(req.params.tid, req.body.expiry, req.uid);
     }
-    yield api.topics.pin(req, { tids: [req.params.tid] });
-    helpers.formatApiResponse(200, res);
-});
-Topics.unpin = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
-    yield api.topics.unpin(req, { tids: [req.params.tid] });
-    helpers.formatApiResponse(200, res);
-});
-Topics.lock = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
-    yield api.topics.lock(req, { tids: [req.params.tid] });
-    helpers.formatApiResponse(200, res);
-});
-Topics.unlock = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
-    yield api.topics.unlock(req, { tids: [req.params.tid] });
-    helpers.formatApiResponse(200, res);
-});
-Topics.follow = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
-    yield api.topics.follow(req, req.params);
-    helpers.formatApiResponse(200, res);
-});
-Topics.ignore = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
-    yield api.topics.ignore(req, req.params);
-    helpers.formatApiResponse(200, res);
-});
-Topics.unfollow = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
-    yield api.topics.unfollow(req, req.params);
-    helpers.formatApiResponse(200, res);
-});
-Topics.addTags = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
-    if (!(yield privileges.topics.canEdit(req.params.tid, req.user.uid))) {
-        return helpers.formatApiResponse(403, res);
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    await api_1.default.topics.pin(req, { tids: [req.params.tid] });
+    await helpers_1.default.formatApiResponse(200, res);
+};
+exports.pin = pin;
+const unpin = async (req, res) => {
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    await api_1.default.topics.unpin(req, { tids: [req.params.tid] });
+    await helpers_1.default.formatApiResponse(200, res);
+};
+exports.unpin = unpin;
+const lock = async (req, res) => {
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    await api_1.default.topics.lock(req, { tids: [req.params.tid] });
+    await helpers_1.default.formatApiResponse(200, res);
+};
+exports.lock = lock;
+const unlock = async (req, res) => {
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    await api_1.default.topics.unlock(req, { tids: [req.params.tid] });
+    await helpers_1.default.formatApiResponse(200, res);
+};
+exports.unlock = unlock;
+const follow = async (req, res) => {
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    await api_1.default.topics.follow(req, req.params);
+    await helpers_1.default.formatApiResponse(200, res);
+};
+exports.follow = follow;
+const ignore = async (req, res) => {
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    await api_1.default.topics.ignore(req, req.params);
+    await helpers_1.default.formatApiResponse(200, res);
+};
+exports.ignore = ignore;
+const unfollow = async (req, res) => {
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    await api_1.default.topics.unfollow(req, req.params);
+    await helpers_1.default.formatApiResponse(200, res);
+};
+exports.unfollow = unfollow;
+const addTags = async (req, res) => {
+    if (!await privileges_1.default.topics.canEdit(req.params.tid, req.user.uid)) {
+        return helpers_1.default.formatApiResponse(403, res);
     }
-    const cid = yield topics.getTopicField(req.params.tid, 'cid');
-    yield topics.validateTags(req.body.tags, cid, req.user.uid, req.params.tid);
-    const tags = yield topics.filterTags(req.body.tags);
-    yield topics.addTags(tags, [req.params.tid]);
-    helpers.formatApiResponse(200, res);
-});
-Topics.deleteTags = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
-    if (!(yield privileges.topics.canEdit(req.params.tid, req.user.uid))) {
-        return helpers.formatApiResponse(403, res);
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    const cid = await topics_1.default.getTopicField(req.params.tid, 'cid');
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    await topics_1.default.validateTags(req.body.tags, cid, req.user.uid, req.params.tid);
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    const tags = await topics_1.default.filterTags(req.body.tags);
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    await topics_1.default.addTags(tags, [req.params.tid]);
+    await helpers_1.default.formatApiResponse(200, res);
+};
+exports.addTags = addTags;
+const deleteTags = async (req, res) => {
+    if (!await privileges_1.default.topics.canEdit(req.params.tid, req.user.uid)) {
+        return helpers_1.default.formatApiResponse(403, res);
     }
-    yield topics.deleteTopicTags(req.params.tid);
-    helpers.formatApiResponse(200, res);
-});
-Topics.getThumbs = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
-    if (isFinite(req.params.tid)) { // post_uuids can be passed in occasionally, in that case no checks are necessary
-        const [exists, canRead] = yield Promise.all([
-            topics.exists(req.params.tid),
-            privileges.topics.can('topics:read', req.params.tid, req.uid),
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    await topics_1.default.deleteTopicTags(req.params.tid);
+    await helpers_1.default.formatApiResponse(200, res);
+};
+exports.deleteTags = deleteTags;
+const getThumbs = async (req, res) => {
+    // post_uuids can be passed in occasionally, in that case no checks are necessary
+    if (isFinite(parseInt(req.params.tid, 10))) {
+        const [exists, canRead] = await Promise.all([
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            topics_1.default.exists(req.params.tid),
+            privileges_1.default.topics.can('topics:read', req.params.tid, req.uid),
         ]);
         if (!exists || !canRead) {
-            return helpers.formatApiResponse(403, res);
+            return helpers_1.default.formatApiResponse(403, res);
         }
     }
-    helpers.formatApiResponse(200, res, yield topics.thumbs.get(req.params.tid));
-});
-Topics.addThumb = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
-    yield checkThumbPrivileges({ tid: req.params.tid, uid: req.user.uid, res });
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    await helpers_1.default.formatApiResponse(200, res, await topics_1.default.thumbs.get(req.params.tid));
+};
+exports.getThumbs = getThumbs;
+async function checkThumbPrivileges({ tid, uid, res }) {
+    // req.params.tid could be either a tid (pushing a new thumb to an existing topic)
+    // or a post UUID (a new topic being composed)
+    const isUUID = validator_1.default.isUUID(tid);
+    // Sanity-check the tid if it's strictly not a uuid
+    if (!isUUID && (isNaN(parseInt(tid, 10)) || !await topics_1.default.exists(tid))) {
+        return helpers_1.default.formatApiResponse(404, res, new Error('[[error:no-topic]]'));
+    }
+    // While drafts are not protected, tids are
+    if (!isUUID && !await privileges_1.default.topics.canEdit(tid, uid)) {
+        return helpers_1.default.formatApiResponse(403, res, new Error('[[error:no-privileges]]'));
+    }
+}
+const addThumb = async (req, res) => {
+    await checkThumbPrivileges({ tid: req.params.tid, uid: req.user.uid, res });
     if (res.headersSent) {
         return;
     }
-    const files = yield uploadsController.uploadThumb(req, res); // response is handled here
+    const files = await uploads_1.default.uploadThumb(req, res); // response is handled here
     // Add uploaded files to topic zset
     if (files && files.length) {
-        yield Promise.all(files.map((fileObj) => __awaiter(void 0, void 0, void 0, function* () {
-            yield topics.thumbs.associate({
+        await Promise.all(files.map(async (fileObj) => {
+            await topics_1.default.thumbs.associate({
                 id: req.params.tid,
                 path: fileObj.path || fileObj.url,
             });
-        })));
+        }));
     }
-});
-Topics.migrateThumbs = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
-    yield Promise.all([
+};
+exports.addThumb = addThumb;
+const migrateThumbs = async (req, res) => {
+    await Promise.all([
         checkThumbPrivileges({ tid: req.params.tid, uid: req.user.uid, res }),
         checkThumbPrivileges({ tid: req.body.tid, uid: req.user.uid, res }),
     ]);
     if (res.headersSent) {
         return;
     }
-    yield topics.thumbs.migrate(req.params.tid, req.body.tid);
-    helpers.formatApiResponse(200, res);
-});
-Topics.deleteThumb = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
+    await topics_1.default.thumbs.migrate(req.params.tid, req.body.tid);
+    await helpers_1.default.formatApiResponse(200, res);
+};
+exports.migrateThumbs = migrateThumbs;
+const deleteThumb = async (req, res) => {
     if (!req.body.path.startsWith('http')) {
-        yield middleware.assert.path(req, res, () => { });
+        middleware_1.default.assert.path(req, res, () => { console.log('complete'); });
         if (res.headersSent) {
             return;
         }
     }
-    yield checkThumbPrivileges({ tid: req.params.tid, uid: req.user.uid, res });
+    await checkThumbPrivileges({ tid: req.params.tid, uid: req.user.uid, res });
     if (res.headersSent) {
         return;
     }
-    yield topics.thumbs.delete(req.params.tid, req.body.path);
-    helpers.formatApiResponse(200, res, yield topics.thumbs.get(req.params.tid));
-});
-Topics.reorderThumbs = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
-    yield checkThumbPrivileges({ tid: req.params.tid, uid: req.user.uid, res });
+    await topics_1.default.thumbs.delete(req.params.tid, req.body.path);
+    await helpers_1.default.formatApiResponse(200, res, await topics_1.default.thumbs.get(req.params.tid));
+};
+exports.deleteThumb = deleteThumb;
+const reorderThumbs = async (req, res) => {
+    await checkThumbPrivileges({ tid: req.params.tid, uid: req.user.uid, res });
     if (res.headersSent) {
         return;
     }
-    const exists = yield topics.thumbs.exists(req.params.tid, req.body.path);
+    const exists = await topics_1.default.thumbs.exists(req.params.tid, req.body.path);
     if (!exists) {
-        return helpers.formatApiResponse(404, res);
+        return helpers_1.default.formatApiResponse(404, res);
     }
-    yield topics.thumbs.associate({
+    await topics_1.default.thumbs.associate({
         id: req.params.tid,
         path: req.body.path,
         score: req.body.order,
     });
-    helpers.formatApiResponse(200, res);
-});
-function checkThumbPrivileges({ tid, uid, res }) {
-    return __awaiter(this, void 0, void 0, function* () {
-        // req.params.tid could be either a tid (pushing a new thumb to an existing topic)
-        // or a post UUID (a new topic being composed)
-        const isUUID = validator.isUUID(tid);
-        // Sanity-check the tid if it's strictly not a uuid
-        if (!isUUID && (isNaN(parseInt(tid, 10)) || !(yield topics.exists(tid)))) {
-            return helpers.formatApiResponse(404, res, new Error('[[error:no-topic]]'));
-        }
-        // While drafts are not protected, tids are
-        if (!isUUID && !(yield privileges.topics.canEdit(tid, uid))) {
-            return helpers.formatApiResponse(403, res, new Error('[[error:no-privileges]]'));
-        }
-    });
-}
-Topics.getEvents = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
-    if (!(yield privileges.topics.can('topics:read', req.params.tid, req.uid))) {
-        return helpers.formatApiResponse(403, res);
+    await helpers_1.default.formatApiResponse(200, res);
+};
+exports.reorderThumbs = reorderThumbs;
+const getEvents = async (req, res) => {
+    if (!await privileges_1.default.topics.can('topics:read', req.params.tid, req.uid)) {
+        return helpers_1.default.formatApiResponse(403, res);
     }
-    helpers.formatApiResponse(200, res, yield topics.events.get(req.params.tid, req.uid));
-});
-Topics.deleteEvent = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
-    if (!(yield privileges.topics.isAdminOrMod(req.params.tid, req.uid))) {
-        return helpers.formatApiResponse(403, res);
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    await helpers_1.default.formatApiResponse(200, res, await topics_1.default.events.get(req.params.tid, req.uid));
+};
+exports.getEvents = getEvents;
+const deleteEvent = async (req, res) => {
+    if (!await privileges_1.default.topics.isAdminOrMod(req.params.tid, req.uid)) {
+        return helpers_1.default.formatApiResponse(403, res);
     }
-    yield topics.events.purge(req.params.tid, [req.params.eventId]);
-    helpers.formatApiResponse(200, res);
-});
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    await topics_1.default.events.purge(req.params.tid, [req.params.eventId]);
+    await helpers_1.default.formatApiResponse(200, res);
+};
+exports.deleteEvent = deleteEvent;

--- a/src/controllers/write/topics.ts
+++ b/src/controllers/write/topics.ts
@@ -12,15 +12,8 @@ import helpers from '../helpers';
 import middleware from '../../middleware';
 import uploadsController from '../uploads';
 
-import { TopicData } from '../../types';
+import { TopicData, TagObject } from '../../types';
 
-interface Tag {
-    value: string;
-    valueEscaped: string;
-    color: string;
-    bgColor: string;
-    score: number;
-}
 
 interface ExtendedRequest extends Request {
     uid: number;
@@ -30,7 +23,7 @@ interface ExtendedRequest extends Request {
     };
     body: {
         expiry: boolean;
-        tags: Tag[];
+        tags: TagObject[];
         path: string;
         tid: string | number;
         order: number;

--- a/src/controllers/write/topics.ts
+++ b/src/controllers/write/topics.ts
@@ -1,0 +1,334 @@
+import validator from 'validator';
+import _ from 'lodash';
+
+import db from '../../database';
+import api from '../../api';
+import topics from '../../topics';
+import privileges from '../../privileges';
+import plugins from '../../plugins';
+
+import helpers from '../helpers';
+import middleware from '../../middleware';
+import uploadsController from '../uploads';
+
+const Topics = module.exports;
+
+Topics.get = async (req, res) => {
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    helpers.formatApiResponse(200, res, await api.topics.get(req, req.params));
+};
+
+Topics.create = async (req, res) => {
+    const id = await lockPosting(req, '[[error:already-posting]]');
+    try {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        const payload = await api.topics.create(req, req.body);
+        if (payload.queued) {
+            helpers.formatApiResponse(202, res, payload);
+        } else {
+            helpers.formatApiResponse(200, res, payload);
+        }
+    } finally {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        await db.deleteObjectField('locks', id);
+    }
+};
+
+Topics.reply = async (req, res) => {
+    const id = await lockPosting(req, '[[error:already-posting]]');
+    try {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        const payload = await api.topics.reply(req, { ...req.body, tid: req.params.tid });
+        helpers.formatApiResponse(200, res, payload);
+    } finally {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        await db.deleteObjectField('locks', id);
+    }
+};
+
+async function lockPosting(req, error) {
+    const id = req.uid > 0 ? req.uid : req.sessionID;
+    const value = `posting${id}`;
+
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    const count = await db.incrObjectField('locks', value);
+    if (count > 1) {
+        throw new Error(error);
+    }
+    return value;
+}
+
+Topics.delete = async (req, res) => {
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    await api.topics.delete(req, { tids: [req.params.tid] });
+    helpers.formatApiResponse(200, res);
+};
+
+// added resolved field
+Topics.resolve = async (req, res) => {
+    await resolve(req.params.tid, req.uid);
+    helpers.formatApiResponse(200, res);
+};
+
+async function resolve(tid, uid) {
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    const topicData = await topics.getTopicFields(tid, ['tid', 'uid', 'cid']);
+    if (!topicData || !topicData.cid) {
+        throw new Error('[[error:no-topic]]');
+    }
+
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    const isOwnerOrAdminOrMod = await privileges.topics.isOwnerOrAdminOrMod(tid, uid);
+    if (!isOwnerOrAdminOrMod) {
+        throw new Error('[[error:no-privileges]]');
+    }
+
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    await topics.setTopicField(tid, 'resolve', true);
+
+    topicData.resolve = true;
+
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    plugins.hooks.fire('action:topic.resolve', { topic: _.clone(topicData), uid: uid });
+    return topicData;
+}
+
+Topics.restore = async (req, res) => {
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    await api.topics.restore(req, { tids: [req.params.tid] });
+
+    helpers.formatApiResponse(200, res);
+};
+
+Topics.purge = async (req, res) => {
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    await api.topics.purge(req, { tids: [req.params.tid] });
+    helpers.formatApiResponse(200, res);
+};
+
+Topics.pin = async (req, res) => {
+    // Pin expiry was not available w/ sockets hence not included in api lib method
+    if (req.body.expiry) {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        await topics.tools.setPinExpiry(req.params.tid, req.body.expiry, req.uid);
+    }
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    await api.topics.pin(req, { tids: [req.params.tid] });
+
+    helpers.formatApiResponse(200, res);
+};
+
+Topics.unpin = async (req, res) => {
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    await api.topics.unpin(req, { tids: [req.params.tid] });
+    helpers.formatApiResponse(200, res);
+};
+
+Topics.lock = async (req, res) => {
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    await api.topics.lock(req, { tids: [req.params.tid] });
+    helpers.formatApiResponse(200, res);
+};
+
+Topics.unlock = async (req, res) => {
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    await api.topics.unlock(req, { tids: [req.params.tid] });
+    helpers.formatApiResponse(200, res);
+};
+
+Topics.follow = async (req, res) => {
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    await api.topics.follow(req, req.params);
+    helpers.formatApiResponse(200, res);
+};
+
+Topics.ignore = async (req, res) => {
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    await api.topics.ignore(req, req.params);
+    helpers.formatApiResponse(200, res);
+};
+
+Topics.unfollow = async (req, res) => {
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    await api.topics.unfollow(req, req.params);
+    helpers.formatApiResponse(200, res);
+};
+
+Topics.addTags = async (req, res) => {
+    if (!await privileges.topics.canEdit(req.params.tid, req.user.uid)) {
+        return helpers.formatApiResponse(403, res);
+    }
+
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    const cid = await topics.getTopicField(req.params.tid, 'cid');
+
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    await topics.validateTags(req.body.tags, cid, req.user.uid, req.params.tid);
+
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    const tags = await topics.filterTags(req.body.tags);
+
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    await topics.addTags(tags, [req.params.tid]);
+    helpers.formatApiResponse(200, res);
+};
+
+Topics.deleteTags = async (req, res) => {
+    if (!await privileges.topics.canEdit(req.params.tid, req.user.uid)) {
+        return helpers.formatApiResponse(403, res);
+    }
+
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    await topics.deleteTopicTags(req.params.tid);
+    helpers.formatApiResponse(200, res);
+};
+
+Topics.getThumbs = async (req, res) => {
+    if (isFinite(req.params.tid)) { // post_uuids can be passed in occasionally, in that case no checks are necessary
+        const [exists, canRead] = await Promise.all([
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            topics.exists(req.params.tid),
+            privileges.topics.can('topics:read', req.params.tid, req.uid),
+        ]);
+        if (!exists || !canRead) {
+            return helpers.formatApiResponse(403, res);
+        }
+    }
+
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    helpers.formatApiResponse(200, res, await topics.thumbs.get(req.params.tid));
+};
+
+Topics.addThumb = async (req, res) => {
+    await checkThumbPrivileges({ tid: req.params.tid, uid: req.user.uid, res });
+    if (res.headersSent) {
+        return;
+    }
+
+    const files = await uploadsController.uploadThumb(req, res); // response is handled here
+
+    // Add uploaded files to topic zset
+    if (files && files.length) {
+        await Promise.all(files.map(async (fileObj) => {
+            await topics.thumbs.associate({
+                id: req.params.tid,
+                path: fileObj.path || fileObj.url,
+            });
+        }));
+    }
+};
+
+Topics.migrateThumbs = async (req, res) => {
+    await Promise.all([
+        checkThumbPrivileges({ tid: req.params.tid, uid: req.user.uid, res }),
+        checkThumbPrivileges({ tid: req.body.tid, uid: req.user.uid, res }),
+    ]);
+    if (res.headersSent) {
+        return;
+    }
+
+    await topics.thumbs.migrate(req.params.tid, req.body.tid);
+    helpers.formatApiResponse(200, res);
+};
+
+Topics.deleteThumb = async (req, res) => {
+    if (!req.body.path.startsWith('http')) {
+        await middleware.assert.path(req, res, () => { });
+        if (res.headersSent) {
+            return;
+        }
+    }
+
+    await checkThumbPrivileges({ tid: req.params.tid, uid: req.user.uid, res });
+    if (res.headersSent) {
+        return;
+    }
+
+    await topics.thumbs.delete(req.params.tid, req.body.path);
+    helpers.formatApiResponse(200, res, await topics.thumbs.get(req.params.tid));
+};
+
+Topics.reorderThumbs = async (req, res) => {
+    await checkThumbPrivileges({ tid: req.params.tid, uid: req.user.uid, res });
+    if (res.headersSent) {
+        return;
+    }
+
+    const exists = await topics.thumbs.exists(req.params.tid, req.body.path);
+    if (!exists) {
+        return helpers.formatApiResponse(404, res);
+    }
+
+    await topics.thumbs.associate({
+        id: req.params.tid,
+        path: req.body.path,
+        score: req.body.order,
+    });
+    helpers.formatApiResponse(200, res);
+};
+
+async function checkThumbPrivileges({ tid, uid, res }) {
+    // req.params.tid could be either a tid (pushing a new thumb to an existing topic)
+    // or a post UUID (a new topic being composed)
+    const isUUID = validator.isUUID(tid);
+
+    // Sanity-check the tid if it's strictly not a uuid
+    if (!isUUID && (isNaN(parseInt(tid, 10)) || !await topics.exists(tid))) {
+        return helpers.formatApiResponse(404, res, new Error('[[error:no-topic]]'));
+    }
+
+    // While drafts are not protected, tids are
+    if (!isUUID && !await privileges.topics.canEdit(tid, uid)) {
+        return helpers.formatApiResponse(403, res, new Error('[[error:no-privileges]]'));
+    }
+}
+
+Topics.getEvents = async (req, res) => {
+    if (!await privileges.topics.can('topics:read', req.params.tid, req.uid)) {
+        return helpers.formatApiResponse(403, res);
+    }
+
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    helpers.formatApiResponse(200, res, await topics.events.get(req.params.tid, req.uid));
+};
+
+Topics.deleteEvent = async (req, res) => {
+    if (!await privileges.topics.isAdminOrMod(req.params.tid, req.uid)) {
+        return helpers.formatApiResponse(403, res);
+    }
+
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    await topics.events.purge(req.params.tid, [req.params.eventId]);
+
+    helpers.formatApiResponse(200, res);
+};

--- a/src/controllers/write/topics.ts
+++ b/src/controllers/write/topics.ts
@@ -14,7 +14,7 @@ import uploadsController from '../uploads';
 
 import { TopicData, TagObject } from '../../types';
 
-
+interface Validator { isUUID: (str: string, version?: validator.UUIDVersion) => boolean; }
 interface ExtendedRequest extends Request {
     uid: number;
     sessionID: number;
@@ -104,7 +104,7 @@ export const deleteTopic = async (req: ExtendedRequest, res: Response) => {
     await helpers.formatApiResponse(200, res);
 };
 
-async function resolveTopic(tid, uid) {
+async function resolveTopic(tid, uid: number) {
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     const topicData = await topics.getTopicFields(tid, ['tid', 'uid', 'cid']) as TopicData;
@@ -223,7 +223,7 @@ export const addTags = async (req: ExtendedRequest, res: Response) => {
 
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-    const tags = await topics.filterTags(req.body.tags) as Tag[];
+    const tags = await topics.filterTags(req.body.tags) as TagObject[];
 
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
@@ -264,7 +264,7 @@ export const getThumbs = async (req: ExtendedRequest, res: Response) => {
 async function checkThumbPrivileges({ tid, uid, res }: { tid: string, uid: number, res: Response }) {
     // req.params.tid could be either a tid (pushing a new thumb to an existing topic)
     // or a post UUID (a new topic being composed)
-    const isUUID = validator.isUUID(tid) as boolean;
+    const isUUID = (validator as Validator).isUUID(tid);
 
     // Sanity-check the tid if it's strictly not a uuid
     if (!isUUID && (isNaN(parseInt(tid, 10)) || !await topics.exists(tid))) {

--- a/src/controllers/write/topics.ts
+++ b/src/controllers/write/topics.ts
@@ -31,6 +31,7 @@ interface ExtendedRequest extends Request {
         tags: Tag[];
         path: string;
         tid: string;
+        order: number;
     }
 }
 
@@ -303,7 +304,7 @@ export const migrateThumbs = async (req: ExtendedRequest, res: Response) => {
 
 export const deleteThumb = async (req: ExtendedRequest, res: Response) => {
     if (!req.body.path.startsWith('http')) {
-        await middleware.assert.path(req, res, () => { });
+        middleware.assert.path(req, res, () => { console.log('complete'); });
         if (res.headersSent) {
             return;
         }
@@ -324,7 +325,7 @@ export const reorderThumbs = async (req: ExtendedRequest, res: Response) => {
         return;
     }
 
-    const exists = await topics.thumbs.exists(req.params.tid, req.body.path);
+    const exists = await topics.thumbs.exists(req.params.tid, req.body.path) as boolean;
     if (!exists) {
         return helpers.formatApiResponse(404, res);
     }

--- a/src/controllers/write/topics.ts
+++ b/src/controllers/write/topics.ts
@@ -11,15 +11,13 @@ import helpers from '../helpers';
 import middleware from '../../middleware';
 import uploadsController from '../uploads';
 
-const Topics = module.exports;
-
-Topics.get = async (req, res) => {
+export const get = async (req, res) => {
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     helpers.formatApiResponse(200, res, await api.topics.get(req, req.params));
 };
 
-Topics.create = async (req, res) => {
+export const create = async (req, res) => {
     const id = await lockPosting(req, '[[error:already-posting]]');
     try {
         // The next line calls a function in a module that has not been updated to TS yet
@@ -37,7 +35,7 @@ Topics.create = async (req, res) => {
     }
 };
 
-Topics.reply = async (req, res) => {
+export const reply = async (req, res) => {
     const id = await lockPosting(req, '[[error:already-posting]]');
     try {
         // The next line calls a function in a module that has not been updated to TS yet
@@ -64,7 +62,7 @@ async function lockPosting(req, error) {
     return value;
 }
 
-Topics.delete = async (req, res) => {
+export const deleteTopic = async (req, res) => {
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     await api.topics.delete(req, { tids: [req.params.tid] });
@@ -72,12 +70,12 @@ Topics.delete = async (req, res) => {
 };
 
 // added resolved field
-Topics.resolve = async (req, res) => {
-    await resolve(req.params.tid, req.uid);
+export const resolve = async (req, res) => {
+    await resolveTopic(req.params.tid, req.uid);
     helpers.formatApiResponse(200, res);
 };
 
-async function resolve(tid, uid) {
+async function resolveTopic(tid, uid) {
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     const topicData = await topics.getTopicFields(tid, ['tid', 'uid', 'cid']);
@@ -104,7 +102,7 @@ async function resolve(tid, uid) {
     return topicData;
 }
 
-Topics.restore = async (req, res) => {
+export const restore = async (req, res) => {
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     await api.topics.restore(req, { tids: [req.params.tid] });
@@ -112,14 +110,14 @@ Topics.restore = async (req, res) => {
     helpers.formatApiResponse(200, res);
 };
 
-Topics.purge = async (req, res) => {
+export const purge = async (req, res) => {
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     await api.topics.purge(req, { tids: [req.params.tid] });
     helpers.formatApiResponse(200, res);
 };
 
-Topics.pin = async (req, res) => {
+export const pin = async (req, res) => {
     // Pin expiry was not available w/ sockets hence not included in api lib method
     if (req.body.expiry) {
         // The next line calls a function in a module that has not been updated to TS yet
@@ -133,49 +131,49 @@ Topics.pin = async (req, res) => {
     helpers.formatApiResponse(200, res);
 };
 
-Topics.unpin = async (req, res) => {
+export const unpin = async (req, res) => {
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     await api.topics.unpin(req, { tids: [req.params.tid] });
     helpers.formatApiResponse(200, res);
 };
 
-Topics.lock = async (req, res) => {
+export const lock = async (req, res) => {
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     await api.topics.lock(req, { tids: [req.params.tid] });
     helpers.formatApiResponse(200, res);
 };
 
-Topics.unlock = async (req, res) => {
+export const unlock = async (req, res) => {
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     await api.topics.unlock(req, { tids: [req.params.tid] });
     helpers.formatApiResponse(200, res);
 };
 
-Topics.follow = async (req, res) => {
+export const follow = async (req, res) => {
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     await api.topics.follow(req, req.params);
     helpers.formatApiResponse(200, res);
 };
 
-Topics.ignore = async (req, res) => {
+export const ignore = async (req, res) => {
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     await api.topics.ignore(req, req.params);
     helpers.formatApiResponse(200, res);
 };
 
-Topics.unfollow = async (req, res) => {
+export const unfollow = async (req, res) => {
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     await api.topics.unfollow(req, req.params);
     helpers.formatApiResponse(200, res);
 };
 
-Topics.addTags = async (req, res) => {
+export const addTags = async (req, res) => {
     if (!await privileges.topics.canEdit(req.params.tid, req.user.uid)) {
         return helpers.formatApiResponse(403, res);
     }
@@ -198,7 +196,7 @@ Topics.addTags = async (req, res) => {
     helpers.formatApiResponse(200, res);
 };
 
-Topics.deleteTags = async (req, res) => {
+export const deleteTags = async (req, res) => {
     if (!await privileges.topics.canEdit(req.params.tid, req.user.uid)) {
         return helpers.formatApiResponse(403, res);
     }
@@ -209,7 +207,7 @@ Topics.deleteTags = async (req, res) => {
     helpers.formatApiResponse(200, res);
 };
 
-Topics.getThumbs = async (req, res) => {
+export const getThumbs = async (req, res) => {
     if (isFinite(req.params.tid)) { // post_uuids can be passed in occasionally, in that case no checks are necessary
         const [exists, canRead] = await Promise.all([
             // The next line calls a function in a module that has not been updated to TS yet
@@ -227,7 +225,7 @@ Topics.getThumbs = async (req, res) => {
     helpers.formatApiResponse(200, res, await topics.thumbs.get(req.params.tid));
 };
 
-Topics.addThumb = async (req, res) => {
+export const addThumb = async (req, res) => {
     await checkThumbPrivileges({ tid: req.params.tid, uid: req.user.uid, res });
     if (res.headersSent) {
         return;
@@ -246,7 +244,7 @@ Topics.addThumb = async (req, res) => {
     }
 };
 
-Topics.migrateThumbs = async (req, res) => {
+export const migrateThumbs = async (req, res) => {
     await Promise.all([
         checkThumbPrivileges({ tid: req.params.tid, uid: req.user.uid, res }),
         checkThumbPrivileges({ tid: req.body.tid, uid: req.user.uid, res }),
@@ -259,7 +257,7 @@ Topics.migrateThumbs = async (req, res) => {
     helpers.formatApiResponse(200, res);
 };
 
-Topics.deleteThumb = async (req, res) => {
+export const deleteThumb = async (req, res) => {
     if (!req.body.path.startsWith('http')) {
         await middleware.assert.path(req, res, () => { });
         if (res.headersSent) {
@@ -276,7 +274,7 @@ Topics.deleteThumb = async (req, res) => {
     helpers.formatApiResponse(200, res, await topics.thumbs.get(req.params.tid));
 };
 
-Topics.reorderThumbs = async (req, res) => {
+export const reorderThumbs = async (req, res) => {
     await checkThumbPrivileges({ tid: req.params.tid, uid: req.user.uid, res });
     if (res.headersSent) {
         return;
@@ -311,7 +309,7 @@ async function checkThumbPrivileges({ tid, uid, res }) {
     }
 }
 
-Topics.getEvents = async (req, res) => {
+export const getEvents = async (req, res) => {
     if (!await privileges.topics.can('topics:read', req.params.tid, req.uid)) {
         return helpers.formatApiResponse(403, res);
     }
@@ -321,7 +319,7 @@ Topics.getEvents = async (req, res) => {
     helpers.formatApiResponse(200, res, await topics.events.get(req.params.tid, req.uid));
 };
 
-Topics.deleteEvent = async (req, res) => {
+export const deleteEvent = async (req, res) => {
     if (!await privileges.topics.isAdminOrMod(req.params.tid, req.uid)) {
         return helpers.formatApiResponse(403, res);
     }

--- a/src/controllers/write/topics.ts
+++ b/src/controllers/write/topics.ts
@@ -14,7 +14,7 @@ import uploadsController from '../uploads';
 export const get = async (req, res) => {
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-    helpers.formatApiResponse(200, res, await api.topics.get(req, req.params));
+    await helpers.formatApiResponse(200, res, await api.topics.get(req, req.params));
 };
 
 export const create = async (req, res) => {
@@ -24,24 +24,10 @@ export const create = async (req, res) => {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
         const payload = await api.topics.create(req, req.body);
         if (payload.queued) {
-            helpers.formatApiResponse(202, res, payload);
+            await helpers.formatApiResponse(202, res, payload);
         } else {
-            helpers.formatApiResponse(200, res, payload);
+            await helpers.formatApiResponse(200, res, payload);
         }
-    } finally {
-        // The next line calls a function in a module that has not been updated to TS yet
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        await db.deleteObjectField('locks', id);
-    }
-};
-
-export const reply = async (req, res) => {
-    const id = await lockPosting(req, '[[error:already-posting]]');
-    try {
-        // The next line calls a function in a module that has not been updated to TS yet
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        const payload = await api.topics.reply(req, { ...req.body, tid: req.params.tid });
-        helpers.formatApiResponse(200, res, payload);
     } finally {
         // The next line calls a function in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
@@ -62,17 +48,31 @@ async function lockPosting(req, error) {
     return value;
 }
 
+export const reply = async (req, res) => {
+    const id = await lockPosting(req, '[[error:already-posting]]');
+    try {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        const payload = await api.topics.reply(req, { ...req.body, tid: req.params.tid });
+        await helpers.formatApiResponse(200, res, payload);
+    } finally {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        await db.deleteObjectField('locks', id);
+    }
+};
+
 export const deleteTopic = async (req, res) => {
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     await api.topics.delete(req, { tids: [req.params.tid] });
-    helpers.formatApiResponse(200, res);
+    await helpers.formatApiResponse(200, res);
 };
 
 // added resolved field
 export const resolve = async (req, res) => {
     await resolveTopic(req.params.tid, req.uid);
-    helpers.formatApiResponse(200, res);
+    await helpers.formatApiResponse(200, res);
 };
 
 async function resolveTopic(tid, uid) {
@@ -98,7 +98,7 @@ async function resolveTopic(tid, uid) {
 
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-    plugins.hooks.fire('action:topic.resolve', { topic: _.clone(topicData), uid: uid });
+    await plugins.hooks.fire('action:topic.resolve', { topic: _.clone(topicData), uid: uid });
     return topicData;
 }
 
@@ -107,14 +107,14 @@ export const restore = async (req, res) => {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     await api.topics.restore(req, { tids: [req.params.tid] });
 
-    helpers.formatApiResponse(200, res);
+    await helpers.formatApiResponse(200, res);
 };
 
 export const purge = async (req, res) => {
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     await api.topics.purge(req, { tids: [req.params.tid] });
-    helpers.formatApiResponse(200, res);
+    await helpers.formatApiResponse(200, res);
 };
 
 export const pin = async (req, res) => {
@@ -128,49 +128,49 @@ export const pin = async (req, res) => {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     await api.topics.pin(req, { tids: [req.params.tid] });
 
-    helpers.formatApiResponse(200, res);
+    await helpers.formatApiResponse(200, res);
 };
 
 export const unpin = async (req, res) => {
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     await api.topics.unpin(req, { tids: [req.params.tid] });
-    helpers.formatApiResponse(200, res);
+    await helpers.formatApiResponse(200, res);
 };
 
 export const lock = async (req, res) => {
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     await api.topics.lock(req, { tids: [req.params.tid] });
-    helpers.formatApiResponse(200, res);
+    await helpers.formatApiResponse(200, res);
 };
 
 export const unlock = async (req, res) => {
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     await api.topics.unlock(req, { tids: [req.params.tid] });
-    helpers.formatApiResponse(200, res);
+    await helpers.formatApiResponse(200, res);
 };
 
 export const follow = async (req, res) => {
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     await api.topics.follow(req, req.params);
-    helpers.formatApiResponse(200, res);
+    await helpers.formatApiResponse(200, res);
 };
 
 export const ignore = async (req, res) => {
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     await api.topics.ignore(req, req.params);
-    helpers.formatApiResponse(200, res);
+    await helpers.formatApiResponse(200, res);
 };
 
 export const unfollow = async (req, res) => {
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     await api.topics.unfollow(req, req.params);
-    helpers.formatApiResponse(200, res);
+    await helpers.formatApiResponse(200, res);
 };
 
 export const addTags = async (req, res) => {
@@ -193,7 +193,7 @@ export const addTags = async (req, res) => {
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     await topics.addTags(tags, [req.params.tid]);
-    helpers.formatApiResponse(200, res);
+    await helpers.formatApiResponse(200, res);
 };
 
 export const deleteTags = async (req, res) => {
@@ -204,7 +204,7 @@ export const deleteTags = async (req, res) => {
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     await topics.deleteTopicTags(req.params.tid);
-    helpers.formatApiResponse(200, res);
+    await helpers.formatApiResponse(200, res);
 };
 
 export const getThumbs = async (req, res) => {
@@ -222,7 +222,7 @@ export const getThumbs = async (req, res) => {
 
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-    helpers.formatApiResponse(200, res, await topics.thumbs.get(req.params.tid));
+    await helpers.formatApiResponse(200, res, await topics.thumbs.get(req.params.tid));
 };
 
 export const addThumb = async (req, res) => {
@@ -254,7 +254,7 @@ export const migrateThumbs = async (req, res) => {
     }
 
     await topics.thumbs.migrate(req.params.tid, req.body.tid);
-    helpers.formatApiResponse(200, res);
+    await helpers.formatApiResponse(200, res);
 };
 
 export const deleteThumb = async (req, res) => {
@@ -271,7 +271,7 @@ export const deleteThumb = async (req, res) => {
     }
 
     await topics.thumbs.delete(req.params.tid, req.body.path);
-    helpers.formatApiResponse(200, res, await topics.thumbs.get(req.params.tid));
+    await helpers.formatApiResponse(200, res, await topics.thumbs.get(req.params.tid));
 };
 
 export const reorderThumbs = async (req, res) => {
@@ -290,7 +290,7 @@ export const reorderThumbs = async (req, res) => {
         path: req.body.path,
         score: req.body.order,
     });
-    helpers.formatApiResponse(200, res);
+    await helpers.formatApiResponse(200, res);
 };
 
 async function checkThumbPrivileges({ tid, uid, res }) {
@@ -316,7 +316,7 @@ export const getEvents = async (req, res) => {
 
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-    helpers.formatApiResponse(200, res, await topics.events.get(req.params.tid, req.uid));
+    await helpers.formatApiResponse(200, res, await topics.events.get(req.params.tid, req.uid));
 };
 
 export const deleteEvent = async (req, res) => {
@@ -328,5 +328,5 @@ export const deleteEvent = async (req, res) => {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     await topics.events.purge(req.params.tid, [req.params.eventId]);
 
-    helpers.formatApiResponse(200, res);
+    await helpers.formatApiResponse(200, res);
 };

--- a/src/routes/write/topics.js
+++ b/src/routes/write/topics.js
@@ -19,7 +19,7 @@ module.exports = function () {
     setupApiRoute(router, 'delete', '/:tid', [...middlewares], controllers.write.topics.purge);
 
     setupApiRoute(router, 'put', '/:tid/state', [...middlewares], controllers.write.topics.restore);
-    setupApiRoute(router, 'delete', '/:tid/state', [...middlewares], controllers.write.topics.delete);
+    setupApiRoute(router, 'delete', '/:tid/state', [...middlewares], controllers.write.topics.deleteTopic);
 
     setupApiRoute(router, 'put', '/:tid/pin', [...middlewares, middleware.assert.topic], controllers.write.topics.pin);
     setupApiRoute(router, 'delete', '/:tid/pin', [...middlewares], controllers.write.topics.unpin);


### PR DESCRIPTION
Resolves #29
## Description
* Created `src/controllers/write/topics.ts` file
* Added missing type annotations to satisfy linter requirements
* Silenced `@typescript-eslint/no-unsafe-member-access` and `@typescript-eslint/no-unsafe-call` errors when calling a function on untranslated modules
* Added missing `await`s

## Motivation and Context
Part of an ongoing effort to translate the codebase to TypeScript

## How Has This Been Tested?
Passes linter & test

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [ ] I have written unit tests for my changes
-   [ ] My change requires a change to the README documentation
-   [ ] I have updated the documentation accordingly, included in this PR

## Other issues / help required
Silenced `@typescript-eslint/no-unsafe-member-access` and `@typescript-eslint/no-unsafe-call` should be deleted once #34 and #33 have been resolved by @aadenuga and @Jakexy.