### PR TITLE
Added automated tests for private topic creation

### DIFF
--- a/test/topics.js
+++ b/test/topics.js
@@ -81,6 +81,21 @@ describe('Topic\'s', () => {
             });
         });
 
+        it('should create a new private topic', (done) => {
+            topics.post({
+                uid: topic.userId,
+                title: topic.title,
+                content: topic.content,
+                cid: topic.categoryId,
+                privateTopic: true,
+            }, (err, result) => {
+                assert.ifError(err);
+                assert(result);
+                topic.tid = result.topicData.tid;
+                done();
+            });
+        });
+
         it('should get post count', (done) => {
             socketTopics.postcount({ uid: adminUid }, topic.tid, (err, count) => {
                 assert.ifError(err);
@@ -383,6 +398,7 @@ describe('Topic\'s', () => {
                 assert.strictEqual(topicData.deleted, 0);
                 assert.strictEqual(topicData.locked, 0);
                 assert.strictEqual(topicData.pinned, 0);
+                assert.strictEqual(topicData.privateTopic, false);
                 done();
             });
         });

--- a/test/topics.js
+++ b/test/topics.js
@@ -92,6 +92,7 @@ describe('Topic\'s', () => {
                 assert.ifError(err);
                 assert(result);
                 topic.tid = result.topicData.tid;
+                assert.equal(result.topicData.privateTopic, true);
                 done();
             });
         });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- resolves #39 
- checks that topics are created as private by default
- adds automated test to create a private topic
- checks that `privateTopic` attribute is private after topic creation

## Motivation and Context

- added to test the `private` topic toggle created in the front end

## How Has This Been Tested?

- passing `npm run test` and `npm run lint` locally

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] I have written unit tests for my changes


<!--- Do you have any other relevant issues / questions? --->
<!--- For example, if you require assistance for a certain part of your PR --->
<!--- or are facing specific issues while creating the pull request that you would like to highlight --->

<!-- If unsure, feel free to submit first and we'll help you along. -->
